### PR TITLE
modules: hal_silabs: Add Silabs Gecko ADC sources

### DIFF
--- a/gecko/CMakeLists.txt
+++ b/gecko/CMakeLists.txt
@@ -23,6 +23,7 @@ zephyr_compile_definitions(
   )
 
 zephyr_sources(                                    emlib/src/em_system.c)
+zephyr_sources_ifdef(CONFIG_SOC_GECKO_ADC          emlib/src/em_adc.c)
 zephyr_sources_ifdef(CONFIG_SOC_GECKO_CMU          emlib/src/em_cmu.c)
 zephyr_sources_ifdef(CONFIG_SOC_GECKO_CORE         emlib/src/em_core.c)
 zephyr_sources_ifdef(CONFIG_SOC_GECKO_CRYOTIMER    emlib/src/em_cryotimer.c)


### PR DESCRIPTION
Enable compilation of Silabs Gecko ADC sources

Signed-off-by: Oane Kingma <o.kingma@interay.com>